### PR TITLE
Изменение имени класса в задаче с unittest

### DIFF
--- a/solutions/unittest_style.py
+++ b/solutions/unittest_style.py
@@ -8,7 +8,7 @@ from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import WebDriverWait
 
 
-class TestAbs(unittest.TestCase):
+class RegistrationFormSuccessFailureTest(unittest.TestCase):
 
     def setUp(self):
         self.browser = webdriver.Chrome()

--- a/solutions/unittest_style.py
+++ b/solutions/unittest_style.py
@@ -8,7 +8,7 @@ from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import WebDriverWait
 
 
-class RegistrationFormSuccessFailureTest(unittest.TestCase):
+class RegistrationFormTest(unittest.TestCase):
 
     def setUp(self):
         self.browser = webdriver.Chrome()


### PR DESCRIPTION
тут изменила название класс с TestAbs на RegistrationFormSuccessFailureTest

что проверяет 2 теста из класса:
1) успешное заполнение формы регистрации на первой странице
2) неуспешное заполнение формы регистрации на второй странице