### PR TITLE
Проанализировать возможность убрать implicitly_wait из задач с pytest_folder (issue_delete_implicitly_wait_from_conftest)

### DIFF
--- a/solutions/pytest_folder/conftest.py
+++ b/solutions/pytest_folder/conftest.py
@@ -29,8 +29,7 @@ def browser(request):
         options = FirefoxOptions()
         options.set_preference("intl.accept_languages", user_language)
         browser = webdriver.Firefox(options=options)
-
-    browser.implicitly_wait(15)
+    browser.implicitly_wait(10)
     yield browser
     browser.quit()
 


### PR DESCRIPTION
1) убрала implicitly wait из pytest_folder/conftest.py
2) проверила

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=edge --language=en
```

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=edge --language=es
```

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=edge --language=fr
```

---

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=firefox --language=en
```

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=firefox --language=es
```

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=firefox --language=fr
```

---

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=chrome --language=en
```

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=chrome --language=es
```

```
pytest -s -q solutions/page_object/test_product_page.py --browser_name=chrome --language=fr
```

---

---

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=edge --language=en
```

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=edge --language=es
```

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=edge --language=fr
```

---

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=firefox --language=en
```

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=firefox --language=es
```

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=firefox --language=fr
```

---

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=chrome --language=en
```

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=chrome --language=es
```

```
pytest -s -q solutions/page_object/test_main_page.py --browser_name=chrome --language=fr
```

несколько раз. Тесты проходят успешно.
Предлагаю убрать implicitly_wait.